### PR TITLE
Fix OpenAI model name

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ app.post('/api/chat', async (req, res) => {
     const response = await axios.post(
       'https://api.openai.com/v1/chat/completions',
       {
-        model: 'gpt-4.1', // or 'gpt-3.5-turbo'
+        model: 'gpt-4', // or 'gpt-3.5-turbo'
         messages: [{ role: 'user', content: prompt }],
       },
       {


### PR DESCRIPTION
## Summary
- target the current `gpt-4` model in the API request

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_683f7ccb75cc8320b60ebf1d3cbb20ae